### PR TITLE
Fix issues with byId and nodeById

### DIFF
--- a/helpers/dijit.js
+++ b/helpers/dijit.js
@@ -32,12 +32,28 @@ module.exports = {
 	byId: function (widgetId) {
 		function getMethods(session, widgetId) {
 			return session.executeAsync(function (widgetId, done) {
+				function getAllProperties(obj){
+					var allProps = [];
+					var curr = obj;
+					while(curr) {
+						var props = Object.getOwnPropertyNames(curr);
+						props.forEach(function (prop){
+							if (allProps.indexOf(prop) === -1)
+								allProps.push(prop);
+						}); 
+						curr = Object.getPrototypeOf(curr)
+					}
+
+					return allProps;
+				}
 				require([ 'dijit/registry', 'dojo/when' ], function (registry, when) {
 					var widget = registry.byId(widgetId);
 					if (!widget) {
 						done(new Error('Could not find widget "' + widgetId + '"'));
 					}
-					when(widget[key].apply(widget, args)).always(done);
+					when(getAllProperties(widget).filter(function (property) {
+						return widget[property] && widget[property].apply
+					})).always(done);
 				});
 			}, [widgetId]);
 		}
@@ -118,6 +134,7 @@ module.exports = {
 				});
 			}, [widgetId, attachPoint]).then(function (node) {
 				setContext(node);
+				return node;
 			});
 		};
 	}

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
 		"url": "https://github.com/dylans/dijit-intern-helper.git"
 	},
 	"devDependencies": {
-		"dojo": "1.11.0-pre",
-		"dijit": "1.11.0-pre",
-		"intern": "3.0.6",
-		"leadfoot": "1.6.5"
+		"dojo": "^1.11.0",
+		"dijit": "^1.11.0",
+		"intern": "^3.0.6",
+		"leadfoot": "^1.6.5"
 	}
 }

--- a/tests/functional/helpers/dijit.js
+++ b/tests/functional/helpers/dijit.js
@@ -1,20 +1,17 @@
 define([
 	'intern!object',
 	'intern/chai!assert',
-	'intern/dojo/node!../../../Command',
+	'intern/dojo/node!leadfoot/Command',
 	'intern/dojo/node!../../../helpers/dijit',
-	'leadfoot/tests/functional/support/util',
 	'require'
-], function (registerSuite, assert, Command, remoteRegistry, util, require) {
+], function (registerSuite, assert, Command, remoteRegistry, require) {
 	registerSuite(function () {
 		var command;
 		return {
 			name: 'dijit-intern-helper/helpers/dijit',
 
 			setup: function () {
-				return util.createSessionFromRemote(this.remote).then(function (session) {
-					command = new Command(session);
-				});
+			    command = new Command(this.remote);
 			},
 
 			'.getProperty': function () {
@@ -53,8 +50,10 @@ define([
 					.setExecuteAsyncTimeout(4000)
 					.then(remoteRegistry.nodeById('foo', 'node'))
 					.then(function (node) {
-						assert.strictEqual(node.tagName, 'div', 'widget.getNode(foo, node).tagName === div');
-					})
+						return node.getTagName();
+					}).then(function(tagName) {
+						assert.strictEqual(tagName, 'div', 'widget.getNode(foo, node).tagName === div');
+					});
 			}
 
 		};

--- a/tests/functional/helpers/dijit.js
+++ b/tests/functional/helpers/dijit.js
@@ -11,7 +11,7 @@ define([
 			name: 'dijit-intern-helper/helpers/dijit',
 
 			setup: function () {
-			    command = new Command(this.remote);
+				command = new Command(this.remote);
 			},
 
 			'.getProperty': function () {

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -15,14 +15,14 @@ define({
 
 	maxConcurrency: 2,
 	tunnel: 'BrowserStackTunnel',
+	reporters: [ 'Combined' ],
 
-	reporters: [ 'combined' ],
-
-	loader: {
+	loaderOptions: {
 		packages: [
 			{ name: 'leadfoot', location: '.' },
 			{ name: 'dojo', location: './node_modules/dojo' },
-			{ name: 'dijit', location: './node_modules/dijit' }
+			{ name: 'dijit', location: './node_modules/dijit' },
+			{ name: 'tests', location: 'tests' }
 		]
 	},
 
@@ -30,7 +30,7 @@ define({
 	],
 
 	functionalSuites: [
-		'dijit-intern-helper/tests/functional/helpers/dijit'
+		'tests/functional/helpers/dijit'
 	],
 
 	excludeInstrumentation: /^(?:tests|node_modules)\//


### PR DESCRIPTION
ById was failing by using an undefined variable, and
nodeById was not returning the found node. Also updated
dependencies, test config, and the nodeById test to use
the leadfoot element API to get the tagName.
